### PR TITLE
Add mobile nav swipe hints

### DIFF
--- a/css/mobile_style.css
+++ b/css/mobile_style.css
@@ -25,6 +25,7 @@
     white-space: nowrap;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none; /* Firefox */
+    position: relative;
   }
   nav::-webkit-scrollbar {
     display: none; /* Chrome/Safari */
@@ -59,6 +60,25 @@
     background: #222;
     color: #fff;
     transform: scale(0.97);
+  }
+
+  nav::before,
+  nav::after {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #ccc;
+    font-size: 1.4rem;
+    pointer-events: none;
+    user-select: none;
+  }
+  nav::before {
+    content: '\2039'; /* left arrow */
+    left: 0.3em;
+  }
+  nav::after {
+    content: '\203A'; /* right arrow */
+    right: 0.3em;
   }
   .hero {
     height: auto;


### PR DESCRIPTION
## Summary
- hint at the scrollable nav by adding pseudo-element arrows in mobile CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877dbd9b1848327b4b4e5061a6cc3ab